### PR TITLE
chore: Refactor eslint rules for grouped imports

### DIFF
--- a/.eslintrc.import.cjs
+++ b/.eslintrc.import.cjs
@@ -29,7 +29,19 @@ module.exports = {
           },
           {
             group: "internal",
-            pattern: "~/**",
+            pattern: "~/constants",
+          },
+          {
+            group: "internal",
+            pattern: "~/routes",
+          },
+          {
+            group: "internal",
+            pattern: "~/components",
+          },
+          {
+            group: "internal",
+            pattern: "~/hooks",
           },
           {
             group: "sibling",


### PR DESCRIPTION
Updated the ESLint rules for arranging imports into more specific groups in the .eslintrc configuration file. This includes groups for constants, routes, components, hooks respectively. Such division will enhance the code readability and maintainability.