### PR TITLE
feat: Add adaptive visibility for double and back in index.module.css

### DIFF
--- a/src/routes/index.module.css
+++ b/src/routes/index.module.css
@@ -162,6 +162,18 @@
 
 				.literal {
 					color: var(--color-accent-3);
+
+					.double {
+						@container (inline-size <= 326px) {
+							display: none;
+						}
+					}
+
+					.back {
+						@container (inline-size > 326px) {
+							display: none;
+						}
+					}
 				}
 			}
 		}

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -36,11 +36,13 @@ export default component$(() => {
 						<span class={styles.kind}>const</span>{" "}
 						<span class={styles.identifier}>githubLink</span> = <br />
 						<span class={styles.literal}>
-							{'"'}
+							<span class={styles.double}>{'"'}</span>
+							<span class={styles.back}>{"`"}</span>
 							<a href={SNS.github.url} target="_blank" rel="noreferrer">
 								{SNS.github.url}
 							</a>
-							{'"'}
+							<span class={styles.double}>{'"'}</span>
+							<span class={styles.back}>{"`"}</span>
 						</span>
 						;
 					</p>


### PR DESCRIPTION
Initialized responsive visibility settings for the 'double' and 'back' elements in index.module.css. Made corresponding changes in index.tsx to introduce these classes. The UI will show 'double' when the inline-size is more than 326px and 'back' when it's less.