### PR TITLE
refactor: Refactor CSS classes in Header and Navigation components

### DIFF
--- a/src/components/ui/header/header.module.css
+++ b/src/components/ui/header/header.module.css
@@ -17,7 +17,7 @@
 		color: var(--color-secondary-1);
 		border-inline-end: var(--border);
 
-		.link {
+		a {
 			display: flex;
 			align-items: center;
 			inline-size: 100%;

--- a/src/components/ui/header/header.tsx
+++ b/src/components/ui/header/header.tsx
@@ -13,7 +13,7 @@ export const Header = component$(() => {
 	return (
 		<header class={styles.header}>
 			<h1 class={styles.title}>
-				<Link class={styles.link} aria-current={isRoot && "page"} href="/">
+				<Link aria-current={isRoot && "page"} href="/">
 					{SITENAME}
 				</Link>
 			</h1>

--- a/src/components/ui/header/navigation.module.css
+++ b/src/components/ui/header/navigation.module.css
@@ -19,7 +19,7 @@
 				border-inline-end: none;
 			}
 
-			.link {
+			a {
 				--padding-inline: 32px;
 
 				display: flex;

--- a/src/components/ui/header/navigation.tsx
+++ b/src/components/ui/header/navigation.tsx
@@ -21,7 +21,7 @@ export const Navigation = component$<Props>(({ location }) => {
 					return (
 						<li key={item}>
 							<Link
-								class={[styles.link, isCurrent && styles.activated]}
+								class={isCurrent && styles.activated}
 								aria-current={isCurrent && "page"}
 								href={pathname}
 							>


### PR DESCRIPTION
The `.link` CSS class in Header and Navigation components was simplified. The class was removed from JSX file and replaced with tag identity in CSS, improving the readability of the code. This change reflects an efficient usage of CSS selectors, making it easier to identify elements and maintain the code in future.