### PR TITLE
chore: Disable textlint-rule-alive-link in config file

### DIFF
--- a/.textlintrc.cjs
+++ b/.textlintrc.cjs
@@ -2,7 +2,7 @@ module.exports = {
 	plugins: {},
 	filters: {},
 	rules: {
-		"textlint-rule-alive-link": true,
+		"textlint-rule-alive-link": false, // TODO: It's too slow, it's just a temporary solution.
 		"@textlint-rule/no-unmatched-pair": true,
 		"textlint-rule-no-zero-width-spaces": true,
 		"textlint-rule-doubled-spaces": true,


### PR DESCRIPTION
The textlint-rule-alive-link has been set to false in the .textlintrc.cjs configuration file due to its slow performance. This change is temporary while a more efficient solution is sought.