### PR TITLE
refactor: Update CSS border properties for better RTL support

### DIFF
--- a/src/components/interface/footer.module.css
+++ b/src/components/interface/footer.module.css
@@ -51,7 +51,7 @@
 		&.github {
 			gap: 7px;
 			padding-inline: 23px;
-			border-bottom-right-radius: var(--border-radius-md);
+			border-end-end-radius: var(--border-radius-md);
 
 			&:is(:focus-visible, :hover) {
 				color: var(--color-foreground-primary);

--- a/src/components/interface/header.module.css
+++ b/src/components/interface/header.module.css
@@ -31,7 +31,7 @@
 			inline-size: 100%;
 			block-size: 100%;
 			padding-inline: 22px;
-			border-top-left-radius: var(--border-radius-md);
+			border-start-start-radius: var(--border-radius-md);
 
 			&:is(:focus-visible, :hover) {
 				color: var(--color-foreground-primary);

--- a/src/components/interface/header/navigation.module.css
+++ b/src/components/interface/header/navigation.module.css
@@ -42,7 +42,7 @@
 				border-inline-start: var(--border);
 
 				.link {
-					border-top-right-radius: var(--border-radius-md);
+					border-start-end-radius: var(--border-radius-md);
 				}
 			}
 		}


### PR DESCRIPTION
The border properties in the CSS of header, navigation, and footer modules have been updated. Replaced 'border-top-right-radius', 'border-top-left-radius', and 'border-bottom-right-radius' with 'border-start-end-radius', 'border-start-start-radius', and 'border-end-end-radius' respectively. These changes will help improve support for right-to-left (RTL) languages.