### PR TITLE
chore: Removed node_modules from excludeFolder in taichi221228.iml

### DIFF
--- a/.idea/taichi221228.iml
+++ b/.idea/taichi221228.iml
@@ -7,7 +7,6 @@
       <excludeFolder url="file://$MODULE_DIR$/tmp" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/server" />
-      <excludeFolder url="file://$MODULE_DIR$/node_modules" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
The node_modules directory has been removed from the excluded folders list in the IntelliJ IDEA project configuration file (taichi221228.iml). This change will allow the IDE to recognize and interact with the node_modules folder.