### PR TITLE
refactor: Remove temporary comments from CSS code

### DIFF
--- a/src/routes/about-me/editor.module.css
+++ b/src/routes/about-me/editor.module.css
@@ -2,6 +2,6 @@
 	display: flex;
 	flex-grow: 1;
 	flex-wrap: wrap;
-	block-size: var(--block-size-main); /* TEMP: */
+	block-size: var(--block-size-main);
 	overflow: scroll;
 }

--- a/src/routes/about-me/editor/pane.module.css
+++ b/src/routes/about-me/editor/pane.module.css
@@ -1,7 +1,7 @@
 .pane {
 	flex-basis: 400px;
 	flex-grow: 1;
-	block-size: var(--block-size-main); /* TEMP: */
+	block-size: var(--block-size-main);
 
 	&:not(:last-child) {
 		border-inline-end: var(--border);

--- a/src/routes/about-me/index.module.css
+++ b/src/routes/about-me/index.module.css
@@ -1,6 +1,6 @@
 .container {
 	display: flex;
-	block-size: var(--block-size-main); /* TEMP: */
+	block-size: var(--block-size-main);
 
 	aside {
 		--inline-size-aside: var(--inline-size-sitetitle);


### PR DESCRIPTION
In this commit, temporary comments were removed from 'block-size' CSS properties in the 'about-me' route styling files. The changes impact the index.module.css, editor.module.css, and editor/pane.module.css files; the previous declaration was finalized and confirmed to be the standard rule to follow.