### PR TITLE
refactor: Update CSS for consistent border handling

### DIFF
--- a/src/components/interface/accordion.module.css
+++ b/src/components/interface/accordion.module.css
@@ -28,13 +28,14 @@
 
 		.container {
 			padding: var(--padding);
+			border-block-end: var(--border);
 		}
 	}
 
-	&:not(:last-child) {
+	&:last-child {
 		.body {
 			.container {
-				border-block-end: var(--border);
+				border-block-end: none;
 			}
 		}
 	}

--- a/src/components/interface/footer.module.css
+++ b/src/components/interface/footer.module.css
@@ -16,13 +16,13 @@
 		}
 	}
 
-	> :not(:last-child) {
+	> * {
 		border-inline-end: var(--border);
-	}
 
-	> :last-child {
-		margin-inline-start: auto;
-		border-inline-start: var(--border);
+		&:last-child {
+			margin-inline-start: auto;
+			border-inline-start: var(--border);
+		}
 	}
 
 	p,

--- a/src/components/interface/header/navigation.module.css
+++ b/src/components/interface/header/navigation.module.css
@@ -7,6 +7,8 @@
 		block-size: 100%;
 
 		li {
+			border-inline-end: var(--border);
+
 			@container (inline-size < 709px) {
 				flex-grow: 1;
 			}
@@ -33,13 +35,10 @@
 				}
 			}
 
-			&:not(:last-child) {
-				border-inline-end: var(--border);
-			}
-
 			&:last-child {
 				margin-inline-start: auto;
 				border-inline-start: var(--border);
+				border-inline-end: none;
 
 				.link {
 					border-start-end-radius: var(--border-radius-md);

--- a/src/routes/about-me/editor/pane.module.css
+++ b/src/routes/about-me/editor/pane.module.css
@@ -2,9 +2,10 @@
 	flex-basis: 400px;
 	flex-grow: 1;
 	block-size: var(--block-size-main);
+	border-inline-end: var(--border);
 
-	&:not(:last-child) {
-		border-inline-end: var(--border);
+	&:last-child {
+		border-inline-end: none;
 	}
 
 	.content {

--- a/src/routes/about-me/sidebar.module.css
+++ b/src/routes/about-me/sidebar.module.css
@@ -13,11 +13,8 @@
 				gap: var(--gap);
 				inline-size: 100%;
 				margin-inline: calc(var(--padding-inline) * -1);
+				color: var(--color-foreground);
 				border-radius: var(--border-radius-sm);
-
-				&:not(:is([disabled], :focus-visible, :hover)) {
-					color: var(--color-foreground);
-				}
 
 				&:is([disabled], :focus-visible, :hover) {
 					color: var(--color-foreground-primary);


### PR DESCRIPTION
Modified CSS across various component to consistently apply borders, especially for the last child elements. Rather than selectively applying borders via the ":not(:last-child)" pseudo-class, borders are now applied generally and removed for last child elements. This streamlined the border handling across different components.