### PR TITLE
refactor: Reorder Prop parameters in Icon component

### DIFF
--- a/src/components/interface/icons/icon.tsx
+++ b/src/components/interface/icons/icon.tsx
@@ -8,6 +8,6 @@ type Props = {
 export type IconProps = Omit<Props, "type">;
 
 /** @package */
-export const Icon = component$(({ class: className, type, ...props }: Props) => {
+export const Icon = component$(({ type, class: className, ...props }: Props) => {
 	return <i class={[className, type]} {...props} />;
 });


### PR DESCRIPTION
The Prop parameters in the Icon component were reordered such that 'type' parameter is now positioned before 'class'. This adjustment in the destructuring will yield the same result but ensures consistency with the order in which these parameters were initially supplied.