### PR TITLE
fix: Update key value in `<ContactsAccordion />`

### DIFF
--- a/src/components/interface/accordions/contacts-accordion.tsx
+++ b/src/components/interface/accordions/contacts-accordion.tsx
@@ -21,7 +21,7 @@ export const ContactsAccordion = component$(() => {
 					),
 				},
 				{
-					key: "mail",
+					key: "phone",
 					item: (
 						<a href={`tel:${PHONE}`}>
 							<PhoneIcon />


### PR DESCRIPTION
The key value for one of the items has been updated from `mail` to `phone` in the `<ContactsAccordion />`. This change ensures the correct icon is displayed for the related contact detail.