### PR TITLE
chore: Add zsh shebang to .husky/pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,5 @@
+#!/usr/bin/env zsh
+
 bun run build.types
 bun lint
 bun run format.check


### PR DESCRIPTION
Added the "zsh shebang" at the beginning of the .husky/pre-commit file. This is meant to explicitly specify that the script should always run in a zsh shell, regardless of the user's default shell setting.