### PR TITLE
fix: Add `className` to `<FolderIcon />`

### DIFF
--- a/src/components/interface/icons/folder-icon.tsx
+++ b/src/components/interface/icons/folder-icon.tsx
@@ -9,6 +9,6 @@ type Props = {
 } & IconProps;
 
 /** @package */
-export const FolderIcon = component$(({ variant, ...props }: Props) => {
-	return <Icon class={styles[`is-${variant}`]} type="ri-folder-3-fill" {...props} />;
+export const FolderIcon = component$(({ variant, class: className, ...props }: Props) => {
+	return <Icon class={[className, styles[`is-${variant}`]]} type="ri-folder-3-fill" {...props} />;
 });


### PR DESCRIPTION
This update allows the FolderIcon component to receive a className prop in addition to the variant. The className prop will then be included in the list of classes for the Icon component. This provides more flexibility when it comes to styling the FolderIcon component.