### PR TITLE
refactor: Refactor `<Icon />` props

### DIFF
--- a/src/components/interface/icons/triangle-icon.tsx
+++ b/src/components/interface/icons/triangle-icon.tsx
@@ -9,6 +9,6 @@ type Props = {
 } & IconProps;
 
 /** @package */
-export const TriangleIcon = component$(({ class: className, direction = "up", ...props }: Props) => {
+export const TriangleIcon = component$(({ direction = "up", class: className, ...props }: Props) => {
 	return <Icon class={[className, styles[direction]]} type="ri-triangle-fill" {...props} />;
 });


### PR DESCRIPTION
The order of properties has been changed in TriangleIcon's component. The 'direction' property was moved before the 'class' property in the function arguments. This commit improves code readability and maintains consistent property order across multiple components.