### PR TITLE
feat: Add disabled style to `<Button />`

### DIFF
--- a/src/components/interface/button.module.css
+++ b/src/components/interface/button.module.css
@@ -4,6 +4,10 @@
 	font-size: var(--font-size-code);
 	border-radius: var(--border-radius-md);
 
+	&[disabled] {
+		opacity: 0.5;
+	}
+
 	&.primary {
 		background-color: var(--color-background-secondary);
 		border: var(--border);


### PR DESCRIPTION
An opacity of 0.5 has been added to the disabled state of buttons. This will visually indicate to users when a button is non-interactable due to it being disabled, improving overall user experience and interface efficiency.