### PR TITLE
style: Reformat renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": [
-		"config:recommended"
-	]
+	"extends": ["config:recommended"]
 }


### PR DESCRIPTION
This commit changes the 'extends' array in renovate.json to a single line format. No change is made to the actual functionality of the file, just a minor cosmetic change to improve readability.