### PR TITLE
chore: Disable dependency dashboard in renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"]
+	"extends": ["config:recommended"],
+	"dependencyDashboard": false
 }


### PR DESCRIPTION
The change in the renovate configuration file disables the dependency dashboard. This was done by appending "dependencyDashboard" to the "extends" section and setting it to false.