### PR TITLE
chore(scripts): Update `lint.fix` arguments in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"format": "concurrently -n \"prettier,biome\" -c \"#F8BC45,#61A5FA\"  \"prettier --write .\" \"bunx @biomejs/biome format --write .\"",
 		"format.check": "concurrently -n \"prettier,biome\" -c \"#F8BC45,#61A5FA\"  \"prettier --check .\" \"bunx @biomejs/biome format .\"",
 		"lint": "concurrently -n \"eslint,biome,stylelint,textlint\" -c \"#4831BD,#61A5FA,#FFF,#259EAC\" \"ESLINT_USE_FLAT_CONFIG=false eslint -c \\\"./eslint.config.cjs\\\" \\\"src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}\\\"\" \"bunx @biomejs/biome lint .\" \"stylelint \\\"src/**/*.css\\\"\" \"textlint -c \\\"./textlint.config.cjs\\\" \\\"{README.md,src/**/*.md}\\\"\"",
-		"lint.fix": "concurrently -n \"eslint,biome,stylelint,textlint\" -c \"#4831BD,#61A5FA,#FFF,#259EAC\" \"ESLINT_USE_FLAT_CONFIG=false eslint -c \\\"./eslint.config.cjs\\\" --fix \\\"src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}\\\"\" \"bunx @biomejs/biome lint --apply .\" \"stylelint --fix \\\"src/**/*.css\\\"\" \"textlint -c \\\"./textlint.config.cjs\\\" --fix \\\"{README.md,src/**/*.md}\\\"\"",
+		"lint.fix": "concurrently -n \"eslint,biome,stylelint,textlint\" -c \"#4831BD,#61A5FA,#FFF,#259EAC\" \"ESLINT_USE_FLAT_CONFIG=false eslint -c \\\"./eslint.config.cjs\\\" --fix \\\"src/**/*.{js,cjs,mjs,jsx,ts,cts,mts,tsx}\\\"\" \"bunx @biomejs/biome lint --write .\" \"stylelint --fix \\\"src/**/*.css\\\"\" \"textlint -c \\\"./textlint.config.cjs\\\" --fix \\\"{README.md,src/**/*.md}\\\"\"",
 		"prepare": "husky",
 		"preview": "qwik build preview && vite preview --open",
 		"start": "vite --open --mode ssr",


### PR DESCRIPTION
related: #262 

The lint.fix script in package.json has been updated. In specific, changed "lint --apply" to "lint --write" for the `bunx @biomejs/biome` command, making the command more descriptive and clear in its action.