### PR TITLE
fix: Fix `<Icon />`s layout

### DIFF
--- a/src/components/interface/icons/icon.module.css
+++ b/src/components/interface/icons/icon.module.css
@@ -1,4 +1,3 @@
 .icon {
 	display: inline-block;
-	line-height: 1;
 }


### PR DESCRIPTION
The line-height property was removed to ensure more consistent vertical alignment of icons with surrounding text. This change helps to avoid any unintended spacing issues and improves the overall visual consistency.