### PR TITLE
fix: Fix `<Footer />` border style

### DIFF
--- a/src/components/interface/footer.module.css
+++ b/src/components/interface/footer.module.css
@@ -17,7 +17,9 @@
 	}
 
 	> * {
-		border-inline-end: var(--border);
+		&:not(:last-child) {
+			border-inline-end: var(--border);
+		}
 
 		&:last-child {
 			margin-inline-start: auto;


### PR DESCRIPTION
Replace direct border on all items with condition to exclude last child, ensuring a cleaner layout by only applying the border to non-last items. This change enhances the visual separation without affecting the last item unnecessarily.