### PR TITLE
fix(docs): Fix build command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ bun preview # or `npm run preview`
 The production build will generate client and server modules by running both client and server build commands. The build command will use Typescript to run a type check on the source code.
 
 ```shell
-bun build # or `npm run build`
+bun run build # or `npm run build`
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
Correct the build command from 'bun build' to 'bun run build' in the README.md file to ensure accurate instructions.