### PR TITLE
chore(compiler): Update module resolution to "Bundler" in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,7 @@
 		"strict": true,
 		"forceConsistentCasingInFileNames": true,
 		"resolveJsonModule": true,
-		"moduleResolution": "node",
+		"moduleResolution": "Bundler",
 		"esModuleInterop": true,
 		"skipLibCheck": true,
 		"incremental": true,


### PR DESCRIPTION
Changed the "moduleResolution" setting from "node" to "Bundler" to improve compatibility with bundling tools.