### PR TITLE
chore(hook): Update commit-msg hook to use bunx instead of npx

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-npx --no -- commitlint --edit $1
+bunx commitlint --edit $1


### PR DESCRIPTION
Switched from npx to bunx for running commitlint in the commit-msg hook.