### PR TITLE
chore(git-hook): Use 'mise x' in Husky hooks for command execution

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,1 @@
-bunx commitlint --edit $1
+mise x -- bunx commitlint --edit $1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env zsh
 
-bun run build.types
-bun lint
-bun run format.check
+mise x -- bun run build.types
+mise x -- bun lint
+mise x -- bun run format.check


### PR DESCRIPTION
Replaced direct execution of commands in Husky hooks with 'mise x' to ensure consistency and possibly handle additional processing or context setting.